### PR TITLE
DRFT-36 merge installed_packages and installed_packages_delta

### DIFF
--- a/kerlescan/profile_parser.py
+++ b/kerlescan/profile_parser.py
@@ -152,6 +152,20 @@ def parse_profile(system_profile, display_name, logger):
         except UnparsableNEVRAError as e:
             logger.warn(e.message)
 
+    for package in system_profile.get("installed_packages_delta", []):
+        try:
+            name, vra = _get_name_vra_from_string(package)
+            if "installed_packages." + name in parsed_profile:
+                if not isinstance(parsed_profile["installed_packages." + name], list):
+                    starter_item = parsed_profile["installed_packages." + name]
+                    parsed_profile["installed_packages." + name] = [starter_item]
+                parsed_profile["installed_packages." + name].append(vra)
+                parsed_profile["installed_packages." + name].sort()
+            else:
+                parsed_profile["installed_packages." + name] = vra
+        except UnparsableNEVRAError as e:
+            logger.warn(e.message)
+
     for interface in system_profile.get("network_interfaces", []):
         try:
             name = interface["name"]


### PR DESCRIPTION
This work is ready for review and discussion, but should not be merged until the accompanying work in drift-backend to update the comparison report is done (which is currently in progress).

I have opted for a package name key and then a sorted list of packages as the value to handle the multiple values instead of say a nested dict in order to follow the Zen of Python "flat is better".

I want to be sure I don't run into any issues with displaying this structure, and also not block anyone else who may need to do kerlescan work (even though we use pinned versions) by complicating the master branch, hence don't merge it yet.