### PR TITLE
Make str_to_bool case-insensitive when parsing string for boolean value

### DIFF
--- a/kerlescan/config.py
+++ b/kerlescan/config.py
@@ -3,12 +3,14 @@ import os
 
 # small helper to convert strings to boolean
 def str_to_bool(s):
-    if s == "True":
-        return True
-    elif s == "False":
-        return False
-    else:
-        raise ValueError
+    try:
+        if s.lower() == "true":
+            return True
+        if s.lower() == "false":
+            return False
+    except AttributeError:
+        raise ValueError("Valid string argument expected")
+    raise ValueError("Unable to determine boolean value from given string argument")
 
 
 log_level = os.getenv("LOG_LEVEL", "INFO")


### PR DESCRIPTION
This should change no other behavior other than making case-insensitive string comparison.  ValueError will be raised in all cases where it used to be raised so no change in calling code will be required.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
