### PR TITLE
[DRFT-309] Adds shared secret

### DIFF
--- a/kerlescan/config.py
+++ b/kerlescan/config.py
@@ -22,6 +22,9 @@ baseline_svc_hostname = os.getenv(
 )
 rbac_svc_hostname = os.getenv("RBAC_SVC_URL", "http://rbac_svc_url_is_not_set")
 hsp_svc_hostname = os.getenv("HSP_SVC_URL", "http://hsp_svc_url_is_not_set")
+
+drift_shared_secret = os.getenv("DRIFT_SHARED_SECRET", None)
+
 prometheus_multiproc_dir = os.getenv("prometheus_multiproc_dir", None)
 
 path_prefix = os.getenv("PATH_PREFIX", "/api/")

--- a/kerlescan/service_interface.py
+++ b/kerlescan/service_interface.py
@@ -1,5 +1,6 @@
 import requests
 
+from kerlescan.config import drift_shared_secret
 from kerlescan.constants import AUTH_HEADER_NAME
 from kerlescan.exceptions import ServiceError, ItemNotReturned, RBACDenied
 
@@ -9,6 +10,13 @@ def get_key_from_headers(incoming_headers):
     return auth key from header
     """
     return incoming_headers.get(AUTH_HEADER_NAME)
+
+
+def internal_auth_header():
+    """
+    returns drift internal header with shared secret
+    """
+    return {"x-rh-drift-internal-api": drift_shared_secret}
 
 
 def _validate_service_response(response, logger):

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -10,7 +10,12 @@ class RBACTests(unittest.TestCase):
     @mock.patch("kerlescan.view_helpers.get_key_from_headers")
     @mock.patch("kerlescan.view_helpers.get_perms")
     def test_has_perm(self, mock_get_perms, mock_get_key):
-        mock_get_key.return_value = "fake key"
+        mock_get_key.return_value = (
+            "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTIxMjcyOSIsICJ0eXBlIjogI"
+            "lN5c3RlbSIsICJhdXRoX3R5cGUiOiAiY2xhc3NpYy1wcm94eSIsICJzeXN0ZW0iOiB7Im"
+            "NuIjogIjIyY2Q4ZTM5LTEzYmItNGQwMi04MzE2LTg0Yjg1MGRjNTEzNiIsICJjZXJ0X3R"
+            "5cGUiOiAic3lzdGVtIn0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fX0K"
+        )
         mock_get_perms.return_value = ["myperm:*:*"]
         mock_request = mm()
         mock_request.path = "/some/path"
@@ -27,7 +32,12 @@ class RBACTests(unittest.TestCase):
     @mock.patch("kerlescan.view_helpers.get_key_from_headers")
     @mock.patch("kerlescan.view_helpers.get_perms")
     def test_missing_perm(self, mock_get_perms, mock_get_key):
-        mock_get_key.return_value = "fake key"
+        mock_get_key.return_value = (
+            "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTIxMjcyOSIsICJ0eXBlIjogI"
+            "lN5c3RlbSIsICJhdXRoX3R5cGUiOiAiY2xhc3NpYy1wcm94eSIsICJzeXN0ZW0iOiB7Im"
+            "NuIjogIjIyY2Q4ZTM5LTEzYmItNGQwMi04MzE2LTg0Yjg1MGRjNTEzNiIsICJjZXJ0X3R"
+            "5cGUiOiAic3lzdGVtIn0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fX0K"
+        )
         mock_get_perms.return_value = ["myperm:*:*"]
         mock_request = mm()
         mock_request.path = "/some/path"


### PR DESCRIPTION
When we receive request with x-rh-identity header containing
indentity -> type with value of "System"
we check for "x-rh-drift-internal-api" header value and if it matches
drift shared secret value we skip a call to RBAC service
as we consider this to be a safe call from our own service.

Also projects with kerlescan can use internal_auth_header method to get
the header and use it with API calls to other Drift services.

The secret is read as DRIFT_SHARED_SECRET from ENV.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [x] Authentication and Password Management
- [ ] Session Management
- [x] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [x] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
