### PR TITLE
add logging of identity if we get 401 back from RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # kerlescan
 shared service lib
 
+## To run tests
+1. `pipenv install --dev`
+2. `pipenv shell`
+3. `nosetests`
+
 ## To run SonarQube:
 1. Make sure that you have SonarQube scanner installed.
 2. Duplicate the `sonar-scanner.properties.sample` config file.


### PR DESCRIPTION
This will log the identity if/when we get a 401 back from RBAC.  The 401 response indicates either no identity was provided, its missing something, or it was messed up.  This will help us figure it out.
I ran this by kaycoth and he gave the ok.  We will change this to log at debug level once we get what we need now.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [x] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
