### PR TITLE
DRFT-766 Fix check_request_from* methods

### DIFF
--- a/kerlescan/view_helpers.py
+++ b/kerlescan/view_helpers.py
@@ -173,9 +173,9 @@ def ensure_entitled(request, app_name, logger):
         raise HTTPError(HTTPStatus.BAD_REQUEST, message="identity not found on request")
 
     # check if the request comes from our own drift service
-    if check_request_from_drift_service(request=request) or check_request_from_turnpike(
-        request=request
-    ):
+    if check_request_from_drift_service(
+        request=request, logger=logger
+    ) or check_request_from_turnpike(request=request, logger=logger):
         return
 
     entitlements = json.loads(base64.b64decode(auth_key)).get("entitlements", {})


### PR DESCRIPTION
Fixes bug related to both `check_requests_from*` methods, which is
missing `logger` arguments

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
