### PR TITLE
[DRFT-921] Exposing Ansible facts on drift comparison table

### DIFF
--- a/kerlescan/constants.py
+++ b/kerlescan/constants.py
@@ -60,3 +60,4 @@ SYSTEM_PROFILE_LISTS_OF_STRINGS_INSTALLED = {"installed_services"}
 SYSTEM_PROFILE_LISTS_OF_STRINGS = {"gpg_pubkeys"}
 GPG_KEY_PREFIX = "gpg-pubkey-"
 SAP_RELATED_FACTS = {"sap_system", "sap_sids", "sap_instance_number", "sap_version"}
+OBJECT_FACTS = {"ansible"}

--- a/kerlescan/profile_parser.py
+++ b/kerlescan/profile_parser.py
@@ -9,6 +9,7 @@ from insights.parsers.installed_rpms import InstalledRpm
 
 from kerlescan.constants import (  # SYSTEM_PROFILE_LISTS_OF_STRINGS,
     GPG_KEY_PREFIX,
+    OBJECT_FACTS,
     SYSTEM_ID_KEY,
     SYSTEM_PROFILE_BOOLEANS,
     SYSTEM_PROFILE_INTEGERS,
@@ -120,6 +121,13 @@ def parse_profile(system_profile, display_name, logger):
             else:
                 parsed_profile["tags." + tag_name] = tag_dict[tag_name][0]
 
+    def _parse_object(objects):
+        for obj in objects:
+            if obj in system_profile.keys():
+                for fact_name in system_profile[obj]:
+                    fact_value = system_profile[obj][fact_name]
+                    parsed_profile[obj + "." + fact_name] = fact_value
+
     # start with metadata that we have brought down from the system record
     parsed_profile = {"id": system_profile[SYSTEM_ID_KEY], "name": display_name}
 
@@ -134,6 +142,8 @@ def parse_profile(system_profile, display_name, logger):
     _parse_lists_of_strings(SYSTEM_PROFILE_LISTS_OF_STRINGS_ENABLED, "enabled")
     _parse_lists_of_strings(SYSTEM_PROFILE_LISTS_OF_STRINGS_INSTALLED, "installed")
     #    _parse_lists_of_strings(SYSTEM_PROFILE_LISTS_OF_STRINGS, None)
+
+    _parse_object(OBJECT_FACTS)
 
     _parse_running_processes(system_profile.get("running_processes", []))
 


### PR DESCRIPTION
This change add a method that parses an object into drift table facts. The object structure is the following:

```
{
obj_key: {
  obj_key1: value1
  obj_key2: value2
  ...
 obj_keyN: valueN
}
}
```

Ansible structure is the following: https://github.com/RedHatInsights/inventory-schemas/blob/b8ebce5339c4b0ffd635a1ff8d7cc223013fda28/tests/utils/valids.py#L117-L122




## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
