### PR TITLE
Consume cloudwatch configuration from Clowder

### DIFF
--- a/kerlescan/cloudwatch.py
+++ b/kerlescan/cloudwatch.py
@@ -2,6 +2,7 @@ import os
 
 import watchtower
 
+from app_common_python import LoadedConfig, isClowderEnabled
 from boto3.session import Session
 
 
@@ -11,17 +12,26 @@ def setup_cw_logging(logger):  # pragma: no cover
 
     from https://github.com/RedHatInsights/cloudwatch-test
     """
-    key_id = os.environ.get("CW_AWS_ACCESS_KEY_ID")
-    secret = os.environ.get("CW_AWS_SECRET_ACCESS_KEY")
+
+    if isClowderEnabled:
+        cloudwatch_cfg = LoadedConfig.logging.cloudwatch
+
+        key_id = cloudwatch_cfg.accessKeyId
+        secret = cloudwatch_cfg.secretAccessKey
+        region = cloudwatch_cfg.region
+        log_group = cloudwatch_cfg.logGroup
+
+    else:
+        key_id = os.environ.get("CW_AWS_ACCESS_KEY_ID")
+        secret = os.environ.get("CW_AWS_SECRET_ACCESS_KEY")
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        log_group = os.environ.get("CW_LOG_GROUP", "platform-dev")
+
     if not (key_id and secret):
         logger.info("CloudWatch logging disabled due to missing access key")
         return
 
-    session = Session(
-        aws_access_key_id=key_id,
-        aws_secret_access_key=secret,
-        region_name=os.environ.get("AWS_REGION", "us-east-1"),
-    )
+    session = Session(aws_access_key_id=key_id, aws_secret_access_key=secret, region_name=region)
 
     try:
         with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
@@ -31,7 +41,7 @@ def setup_cw_logging(logger):  # pragma: no cover
 
     handler = watchtower.CloudWatchLogHandler(
         boto3_session=session,
-        log_group=os.environ.get("CW_LOG_GROUP", "platform-dev"),
+        log_group=log_group,
         stream_name=namespace,
         create_log_group=False,
     )


### PR DESCRIPTION
This PR add a code to consume Cloudwatch configuration from Clowder.
It keeps the old way of consuming the config from env variables as well!

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
