### PR TITLE
Use TLS for connections according to Clowder config

### DIFF
--- a/kerlescan/config.py
+++ b/kerlescan/config.py
@@ -32,6 +32,15 @@ def load_hosts_setting(env_name, clowder_endpoint, default):
     return os.getenv(env_name, default)
 
 
+def load_setting(env_name, clowder_key, default):
+    if isClowderEnabled():
+        return getattr(LoadedConfig, clowder_key, None)
+
+    return os.getenv(env_name, default)
+
+
+tls_ca_path = load_setting("TLS_CA_PATH", "tlsCAPath", None)
+
 inventory_svc_hostname = load_hosts_setting(
     "INVENTORY_SVC_URL", "host-inventory", "http://inventory_svc_url_is_not_set"
 )

--- a/kerlescan/config.py
+++ b/kerlescan/config.py
@@ -21,8 +21,8 @@ def load_hosts_setting(env_name, clowder_endpoint, default):
         final_endpoint = ""
         for endpoint in cfg.endpoints:
             if endpoint.app == clowder_endpoint:
-                scheme = "http"
-                port = endpoint.port
+                scheme = "https" if cfg.tlsCAPath else "http"
+                port = endpoint.tlsPort if cfg.tlsCAPath else endpoint.port
                 final_endpoint = f"{scheme}://{endpoint.hostname}:{port}"
                 return final_endpoint
 

--- a/kerlescan/config.py
+++ b/kerlescan/config.py
@@ -21,7 +21,9 @@ def load_hosts_setting(env_name, clowder_endpoint, default):
         final_endpoint = ""
         for endpoint in cfg.endpoints:
             if endpoint.app == clowder_endpoint:
-                final_endpoint = f"http://{endpoint.hostname}:{endpoint.port}"
+                scheme = "http"
+                port = endpoint.port
+                final_endpoint = f"{scheme}://{endpoint.hostname}:{port}"
                 return final_endpoint
 
         if final_endpoint == "":

--- a/kerlescan/service_interface.py
+++ b/kerlescan/service_interface.py
@@ -1,6 +1,6 @@
 import requests
 
-from kerlescan.config import drift_shared_secret
+from kerlescan.config import drift_shared_secret, tls_ca_path
 from kerlescan.constants import AUTH_HEADER_NAME, VALID_HTTP_VERBS
 from kerlescan.exceptions import IllegalHttpMethodError, ItemNotReturned, RBACDenied, ServiceError
 
@@ -53,7 +53,7 @@ def fetch_url(url, auth_header, logger, time_metric, exception_metric, method="g
     logger.debug("fetching %s" % url)
     with time_metric.time():
         with exception_metric.count_exceptions():
-            response = requests.request(method, url, headers=auth_header)
+            response = requests.request(method, url, headers=auth_header, verify=tls_ca_path)
     logger.debug("fetched %s" % url)
     _validate_service_response(response, logger, auth_header)
     return response.json()


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-99

- Parametrizes endpoint generation from clowder in config
- Loads tlsCAPath from clowder if present
- Sets endpoint scheme and port depending on tlsCAPath present
- Specifies tls_ca_path to use with requests

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [x] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [x] Communication Security
- [x] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
